### PR TITLE
Cachefix

### DIFF
--- a/js/dbupdate.js
+++ b/js/dbupdate.js
@@ -21,6 +21,7 @@ matruspDB.metadata.get('ETag').then((etag) => {
 
     // Update the indexedDB and put new etag when done
     self.postMessage(0.1);
+    await Promise.all([matruspDB.trigrams.clear(),matruspDB.lectures.clear()]);
     await loadDB (await response.json()); 
     await matruspDB.metadata.put(response.headers.get("ETag"),"ETag");
     self.postMessage(1);

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -8,12 +8,12 @@ self.CURDirs = [
   "/js/.+",
   "/styles/css/application.css",
   "/images/.+"
-  ].map(dir => new RegExp(self.location.origin + dir));
+  ].map(dir => new RegExp(`^${self.location.origin}.+${dir}$`));
 
 //Lista de diretórios que seguem o modelo Network-Cache
 self.NCDirs = [
-  "data/.+" //Identificadores baixados não mostrarão mensagem de atualização
-].map(dir => new RegExp(self.location.origin + dir));
+  "/data/.+" //Identificadores baixados não mostrarão mensagem de atualização
+].map(dir => new RegExp(`^${self.location.origin}.+${dir}$`));
 
 self.addEventListener('fetch', e => {
   // Responder a um fetch com uma resposta do cache(se o diretório estiver na lista)
@@ -64,12 +64,12 @@ function sendRefreshMessage() {
 }
 
 async function networkCache(request) {
-  cacheResponse = await self.caches.open(CACHE_NAME).then(cache => cache.match(request));
+  var cacheResponse = await self.caches.open(CACHE_NAME).then(cache => cache.match(request));
 
   try {
-    netResponse = await fetch(request.url, {method: 'GET', headers: {'If-None-Match': cacheResponse ? cacheResponse.headers.get("ETag").replace('-gzip','') : ''}});
+    var netResponse = await fetch(request.url, {method: 'GET', headers: {'If-None-Match': cacheResponse ? cacheResponse.headers.get("ETag").replace('-gzip','') : ''}});
     if(netResponse.ok) {
-      self.caches.open(CACHE_NAME.then(cache => cache.put(request,netResponse)));
+      await self.caches.open(CACHE_NAME).then(cache => cache.put(request,netResponse.clone()));
       return netResponse;
     }
     else return cacheResponse;

--- a/serviceworker.js
+++ b/serviceworker.js
@@ -1,81 +1,34 @@
 var CACHE_NAME = "Matrusp";
 
-//Lista de diretórios para serem mantidos no cache.
-//Endereços não presentes nessa lista serão buscados da rede
-self.alwaysDirs = [
-  "./",
-  "matrusp.webmanifest",
-  "js/redirect.js",
-  "js/classroom.js",
-  "js/combination.js",
-  "js/custom_lib.js",
-  "js/fbhelper.js",
-  "js/googlecalendar.js",
-  "js/html2canvas.min.js",
-  "js/icalendar.js",
-  "js/image.js",
-  "js/jspdf.min.js",
-  "js/jspdf.plugin.autotable.js",
-  "js/lecture.js",
-  "js/main.js",
-  "js/pdf.js",
-  "js/plan.js",
-  "js/polyfill.js",
-  "js/schedule.js",
-  "js/search_box.js",
-  "js/state.js",
-  "js/ui.js",
-  "js/vfs_fonts.js",
-  "js/file.js",
-  "js/dexie.min.js",
-  "js/dbhelpers.js",
-  "js/dbsearch.js",
-  "js/dbupdate.js",
-  "styles/css/application.css",
-  "images/matrusp16.png",
-  "images/matrusp24.png",
-  "images/matrusp32.png",
-  "images/matrusp48.png",
-  "images/matrusp64.png",
-  "images/matrusp128.png",
-  "images/matrusp192.png",
-  "images/ic_add.png",
-  "images/ic_arrow_down.png",
-  "images/ic_arrow_up.png",
-  "images/ic_calendar.png",
-  "images/ic_close.png",
-  "images/ic_delete.png",
-  "images/ic_download.png",
-  "images/ic_email.png",
-  "images/ic_facebook.png",
-  "images/ic_print.png",
-  "images/ic_upload.png",
-  "images/stripes.gif"
-  ].map(dir => new URL(dir,self.location.href).href);
+//Lista de diretórios que obedecem o padrão Cache-Update-Refresh.
+//Endereços não presentes nessas listas serão buscados da rede sempre
+self.CURDirs = [
+  "/",
+  "/matrusp.webmanifest",
+  "/js/.+",
+  "/styles/css/application.css",
+  "/images/.+"
+  ].map(dir => new RegExp(self.location.origin + dir));
 
-self.onDemandDirs = [
-  "data/" //Identificadores baixados serão salvos em cache
-].map(dir => new URL(dir, self.location.href).href);
-
-self.addEventListener('install', e => {
-  // Verificar se todos os arquivos estão em cache quando o SW é instalado
-  e.waitUntil(Promise.all(self.alwaysDirs.map(dir => fromCache(new Request(dir.href)))));
-});
+//Lista de diretórios que seguem o modelo Network-Cache
+self.NCDirs = [
+  "data/.+" //Identificadores baixados não mostrarão mensagem de atualização
+].map(dir => new RegExp(self.location.origin + dir));
 
 self.addEventListener('fetch', e => {
   // Responder a um fetch com uma resposta do cache(se o diretório estiver na lista)
-  if(self.alwaysDirs.some(dir => e.request.url.indexOf(dir) > -1)) {
-    e.respondWith(fromCache(e.request.clone(), true)); //Enviar mensagem de atualização ao cliente
+  if(self.CURDirs.some(dir => dir.test(e.request.url))) {
+    e.respondWith(cacheUpdateRefresh(e.request.clone())); //Envia mensagem de atualização ao cliente
   }
-  else if(self.onDemandDirs.some(dir => e.request.url.indexOf(dir) > -1)) {
-    e.respondWith(fromCache(e.request.clone(), false)); //Não enviar mensagem de atualização
+  else if(self.NCDirs.some(dir => dir.test(e.request.url))) {
+    e.respondWith(networkCache(e.request.clone())); //Não envia mensagem de atualização
   }
 
   // Senão, responder com um pedido para a rede
   else e.respondWith(fetch(e.request.clone()));
 });
 
-function fromCache(request, sendMessage) {
+function cacheUpdateRefresh(request) {
   return self.caches.open(CACHE_NAME).then(cache => cache.match(request).then(response => {
     if(!response) {
       // Se o pedido não for encontrado em cache, retornar da network e colocar o resultado em cache
@@ -89,11 +42,11 @@ function fromCache(request, sendMessage) {
 
     // Se o pedido for encontrado em cache, fazer um pedido para a rede e colocar em cache, mas retornar a resposta do cache
     //  antes que ele seja concluido. Enviar o ETag da resposta salva para evitar baixar conteúdo repetido.
-    fetch(request.url, {method: 'GET', headers: {'If-None-Match': response.headers.get("ETag")}}).then(async newresponse => {
+    fetch(request.url, {method: 'GET', headers: {'If-None-Match': response.headers.get("ETag").replace('-gzip','')}}).then(async newresponse => {
       if(newresponse.ok) {
         cache = await self.caches.open(CACHE_NAME);
         cache.add(request,newresponse);
-        if(sendMessage) sendRefreshMessage();
+        sendRefreshMessage();
       }
     }).catch(e => {});
     return response;
@@ -108,4 +61,22 @@ function sendRefreshMessage() {
       client.postMessage('refresh');
     });
   }),1000);
+}
+
+async function networkCache(request) {
+  cacheResponse = await self.caches.open(CACHE_NAME).then(cache => cache.match(request));
+
+  try {
+    netResponse = await fetch(request.url, {method: 'GET', headers: {'If-None-Match': cacheResponse ? cacheResponse.headers.get("ETag").replace('-gzip','') : ''}});
+    if(netResponse.ok) {
+      self.caches.open(CACHE_NAME.then(cache => cache.put(request,netResponse)));
+      return netResponse;
+    }
+    else return cacheResponse;
+  }
+  catch(e) {
+    if(cacheResponse)
+      return cacheResponse;
+    else throw e;
+  }
 }


### PR DESCRIPTION
Fiz algumas mudanças no cache para contornar o erro causado pela resposta de ETag do servidor, e também alguns bugs que encontrei.
Agora apenas os arquivos corretos devem estar em cache (o arquivo db.json não deve) e seguindo a filosofia de cache correta para cada arquivo (os identificadores salvos usam o cache apenas como fallback, sempre preferindo a versão mais atual)

PS. Percebi que o júpiter está se preparando para o próximo semestre, e por enquanto nenhuma disciplina tem oferecimento, logo o MatrUSP não está funcional. Acho que assim que os oferecimentos forem colocados será possível fazer um teste final de funcionalidade e fazer um post sobre as mudanças feitas.