### PR TITLE
Errors de exportação para formato .ics em js/icalendar.js

### DIFF
--- a/js/icalendar.js
+++ b/js/icalendar.js
@@ -1,26 +1,28 @@
-var header_statement = 'BEGIN:VCALENDAR\n' +
-  'PRODID:-\n' +
-  'VERSION:2.0\n';
+var header_statement = 'BEGIN:VCALENDAR\r\n' +
+  'PRODID:-\r\n' +
+  'VERSION:2.0\r\n';
+
+// '\r\n' instead of '\n' for compliance with RFC 5545
 
 //TODO: Decidir se a definição de timezones será utilizada
-var time_zones_statement = 'BEGIN:VTIMEZONE\n' +
-  'TZID:America/Sao_Paulo\n' +
-  'X-LIC-LOCATION:America/Sao_Paulo\n' +
-  'BEGIN:DAYLIGHT\n' +
-  'TZOFFSETFROM:-0300\n' +
-  'TZOFFSETTO:-0200\n' +
-  'TZNAME:BRST\n' +
-  'DTSTART:19701018T000000\n' +
-  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=3SU\n' +
-  'END:DAYLIGHT\n' +
-  'BEGIN:STANDARD\n' +
-  'TZOFFSETFROM:-0300\n' +
-  'TZOFFSETTO:-0300\n' +
-  'TZNAME:BRT\n' +
-  'DTSTART:19700215T000000\n' +
-  'RRULE:FREQ=YEARLY;BYMONTH=2;BYDAY=3SU\n' +
-  'END:STANDARD\n' +
-  'END:VTIMEZONE\n';
+var time_zones_statement = 'BEGIN:VTIMEZONE\r\n' +
+  'TZID:America/Sao_Paulo\r\n' +
+  'X-LIC-LOCATION:America/Sao_Paulo\r\n' +
+  'BEGIN:DAYLIGHT\r\n' +
+  'TZOFFSETFROM:-0300\r\n' +
+  'TZOFFSETTO:-0200\r\n' +
+  'TZNAME:BRST\r\n' +
+  'DTSTART:19701018T000000\r\n' +
+  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=3SU\r\n' +
+  'END:DAYLIGHT\r\n' +
+  'BEGIN:STANDARD\r\n' +
+  'TZOFFSETFROM:-0300\r\n' +
+  'TZOFFSETTO:-0300\r\n' +
+  'TZNAME:BRT\r\n' +
+  'DTSTART:19700215T000000\r\n' +
+  'RRULE:FREQ=YEARLY;BYMONTH=2;BYDAY=3SU\r\n' +
+  'END:STANDARD\r\n' +
+  'END:VTIMEZONE\r\n';
 
 var final_statement = 'END:VCALENDAR';
 
@@ -45,7 +47,9 @@ function get_week_day_number(schedule) {
 }
 
 function get_utc_current_date_and_time() {
-  return new Date().toISOString().replace(/-|:|\./g, "");
+  // ISO: YYYY-MM-DDTHH:mm:ss.sssZ
+  // returned: YYYYMMDDTHHmmssZ
+  return new Date().toISOString().replace(/-|:|\./g, "").slice(0, -4) + "Z";
 }
 
 function generate_uid(schedule) {
@@ -56,18 +60,18 @@ function build_event() {
   var events_statement = "";
   state.activePlan.activeCombination.classroomGroups.map(group => group[0]).forEach(classroom => {
     classroom.schedules.forEach(schedule => {
-      events_statement += "BEGIN:VEVENT\n";
-      events_statement += `DTSTART:${schedule.dateBegin.clone().add({hours: schedule.timeBegin.getHours(), minutes: schedule.timeBegin.getMinutes()}).toIcalString()}\n`;
-      events_statement += `DTEND:${schedule.dateBegin.clone().add({hours: schedule.timeEnd.getHours(), minutes: schedule.timeEnd.getMinutes()}).toIcalString()}\n`;
-      events_statement += `RRULE:FREQ=WEEKLY;UNTIL=${classroom.dateEnd.clone().add({hours: schedule.timeEnd.getHours(), minutes: schedule.timeEnd.getMinutes()}).toIcalString()};BYDAY=\n`;
-      events_statement += `DTSTAMP:${Date.now()}\n`;
-      events_statement += `UID:${generate_uid(schedule)}\n`;
-      events_statement += "SEQUENCE:0\n";
-      events_statement += "STATUS:CONFIRMED\n";
-      events_statement += `SUMMARY: Aula de ${classroom.parent.name} (${classroom.parent.code})\n`;
-      events_statement += `DESCRIPTION:${classroom.obs? classroom.obs.replace(/\n/,' ') : ''}\n`;
-      events_statement += "TRANSP:OPAQUE\n";
-      events_statement += "END:VEVENT\n";
+      events_statement += "BEGIN:VEVENT\r\n";
+      events_statement += `DTSTART:${schedule.dateBegin.clone().add({hours: schedule.timeBegin.getHours(), minutes: schedule.timeBegin.getMinutes()}).toIcalString()}\r\n`;
+      events_statement += `DTEND:${schedule.dateBegin.clone().add({hours: schedule.timeEnd.getHours(), minutes: schedule.timeEnd.getMinutes()}).toIcalString()}\r\n`;
+      events_statement += `RRULE:FREQ=WEEKLY;UNTIL=${classroom.dateEnd.clone().add({hours: schedule.timeEnd.getHours(), minutes: schedule.timeEnd.getMinutes()}).toIcalString()}\r\n`;
+      events_statement += `DTSTAMP:${get_utc_current_date_and_time()}\r\n`;
+      events_statement += `UID:${generate_uid(schedule)}\r\n`;
+      events_statement += "SEQUENCE:0\r\n";
+      events_statement += "STATUS:CONFIRMED\r\n";
+      events_statement += `SUMMARY: Aula de ${classroom.parent.name} (${classroom.parent.code})\r\n`;
+      events_statement += `DESCRIPTION:${classroom.obs? classroom.obs.replace(/\r\n/,' ') : ''}\r\n`;
+      events_statement += "TRANSP:OPAQUE\r\n";
+      events_statement += "END:VEVENT\r\n";
     });
   });
   return events_statement;
@@ -75,7 +79,7 @@ function build_event() {
 
 function download_icalendar() {
   if (state.activePlan.activeCombination == null) {
-    ui.showBanner("Insira uma ou mais matérias antes exportar para um arquivo ics", 2000);
+    ui.showBanner("Insira uma ou mais matérias antes de exportar para um arquivo ics", 2000);
     return;
   }
   var element = document.createElement('a');


### PR DESCRIPTION
Deletado um 'BYDAY=' perdido (mencionado em #93), alterada a função usada em 'DTSTAMP' (para usar o formato ISO em vez de uma marca temporal unix) e uso de `\r\n` em vez de apenas `\n` para conformidade com [RFC 5545](https://tools.ietf.org/html/rfc5545#section-3.1).
Baseei-me nos erros reportados por [este validador online](https://icalendar.org/validator.html).